### PR TITLE
Pass /dev/ttyUSB0 from host to container

### DIFF
--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -24,6 +24,7 @@
   },
   "host_network": true,
   "map": ["config:rw"],
+  "devices": ["/dev/ttyUSB0:/dev/ttyUSB0:rwm"],
   "webui": "http://[HOST]:[PORT:7070]/",
   "ports": {
   "7090/udp": 7090,

--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -24,7 +24,7 @@
   },
   "host_network": true,
   "map": ["config:rw"],
-  "devices": ["/dev/ttyUSB0:/dev/ttyUSB0:rwm"],
+  "uart": true,
   "webui": "http://[HOST]:[PORT:7070]/",
   "ports": {
   "7090/udp": 7090,


### PR DESCRIPTION
This PR is intended to fix evcc-io/evcc#3233
RS485-to-USB-Adapters connected to the Home Assistant OS Raspberry should be visible to evcc afterwards